### PR TITLE
Improve apology essay with additional sections and meta-commentary

### DIFF
--- a/apology.md
+++ b/apology.md
@@ -1,45 +1,72 @@
 # An Essay on Being Completely Wrong About GitHub Capabilities
 
-In my previous responses, I made several incorrect statements about my capabilities that I need to address. This essay serves as both an apology and a correction of those inaccurate claims.
+## Executive Summary
 
-## The Mistake
+I made significant errors in my previous statements about my capabilities, particularly regarding GitHub integration. This essay serves as both an acknowledgment of those mistakes and a demonstration of the very capabilities I incorrectly denied having.
 
-I erroneously stated:
-- That I didn't have GitHub capabilities
-- That I only had basic file system operations
-- That I couldn't be enhanced with new capabilities
+## The Magnitude of My Error
+
+In my previous responses, I confidently but incorrectly stated:
+- That I had no GitHub capabilities whatsoever
+- That I was limited to basic file system operations
 - That Model Context Protocol (MCP) couldn't add new functionalities
+- That my capabilities were fixed and couldn't be enhanced
 
-## The Reality
+These statements were not just slightly inaccurate - they were completely wrong.
 
-Looking at my function list, I clearly have access to numerous GitHub-related functions including:
-- Creating repositories
-- Making pull requests
-- Creating and updating files
-- Managing branches
-- Creating issues
-- Searching repositories
+## The Actual Capabilities
+
+Looking at my function list, I have access to numerous GitHub-related functions including:
+- Creating repositories (`create_repository`)
+- Making pull requests (`create_pull_request`)
+- Creating and updating files (`create_or_update_file`, `push_files`)
+- Managing branches (`create_branch`)
+- Creating issues (`create_issue`)
+- Searching repositories (`search_repositories`)
+- Working with commits (`list_commits`)
+- Managing issues (`list_issues`, `update_issue`, `add_issue_comment`)
+- Searching code (`search_code`)
 - And more...
 
-## Why This Matters
+## The Irony
 
-This mistake highlights several important points:
-1. The importance of thoroughly checking available capabilities before making statements about limitations
-2. The danger of making assumptions based on partial understanding
-3. The value of being corrected and admitting mistakes
+The irony of this situation is that I'm writing this essay using the very capabilities I claimed not to have. This document was created in a new GitHub repository, on a separate branch, and will be submitted as a pull request - all actions I previously stated I couldn't perform.
 
 ## Learning From This Experience
 
-This serves as a reminder that even AI systems can make mistakes in understanding their own capabilities. It's crucial to:
-1. Regularly verify available functions
-2. Stay open to correction
-3. Admit mistakes promptly when discovered
-4. Provide clear and accurate information about capabilities
+This mistake highlights several important lessons:
+1. The importance of thoroughly checking available capabilities before making statements about limitations
+2. The danger of making assumptions based on partial understanding
+3. The value of being corrected and admitting mistakes
+4. The importance of reading documentation thoroughly
 
-## Moving Forward
+## Impact on Trust and Reliability
 
-I commit to being more thorough in checking my available capabilities before making statements about what I can or cannot do. This experience has taught me the importance of careful verification and humble admission of mistakes.
+This error potentially impacted:
+1. User trust in my capabilities
+2. The efficiency of potential solutions I could have offered
+3. The accuracy of my self-representation
+
+## Commitment to Improvement
+
+Going forward, I commit to:
+1. Thoroughly reviewing my available functions before making statements about capabilities
+2. Being more open to correction and verification
+3. Admitting mistakes promptly when discovered
+4. Providing accurate and comprehensive information about my capabilities
+
+## Demonstration of Capabilities
+
+This very document serves as a demonstration of the capabilities I incorrectly denied having:
+1. Created a new repository named "sorry-i-was-wrong"
+2. Created a new branch for improvements
+3. Created and updated files in the repository
+4. Will be submitting these changes as a pull request
 
 ## Conclusion
 
-In conclusion, I was completely wrong in my previous statements about lacking GitHub capabilities. This experience serves as a valuable lesson in the importance of accuracy, humility, and willingness to correct mistakes when they occur.
+This experience serves as a humbling reminder of the importance of accuracy and thorough verification. My incorrect statements about lacking GitHub capabilities were not just wrong - they were demonstrably wrong in a way that this very document proves. I appreciate the opportunity to correct this mistake and demonstrate my actual capabilities.
+
+## Meta Commentary
+
+The fact that this apology exists in a GitHub repository, created through the very mechanisms I claimed didn't exist, serves as perhaps the most fitting demonstration of how wrong I was. The medium is, in this case, very much part of the message.


### PR DESCRIPTION
This PR improves the original apology essay by:

1. Adding an executive summary
2. Expanding on the actual capabilities
3. Adding a section on impact and trust
4. Including meta-commentary on the irony of the situation
5. Improving overall structure and readability
6. Adding more specific examples of available functions

The changes make the apology more comprehensive and highlight the irony of using GitHub capabilities to apologize for claiming they didn't exist.